### PR TITLE
fix: default invalid student ell status to None

### DIFF
--- a/clever/models/student.py
+++ b/clever/models/student.py
@@ -219,7 +219,6 @@ class Student(object):
         allowed_values = ["Y", "N", ""]  # noqa: E501
         if ell_status not in allowed_values:
             warnings.warn(f"Invalid value for ell_status: '{ell_status}'. Must be one of {allowed_values}. Defaulting to None.")
-            ell_status = None
 
         self._ell_status = ell_status
 

--- a/clever/models/student.py
+++ b/clever/models/student.py
@@ -11,7 +11,8 @@
 """
 
 import pprint
-import re  # noqa: F401
+import re
+import warnings  # noqa: F401
 
 import six
 
@@ -217,10 +218,8 @@ class Student(object):
         """
         allowed_values = ["Y", "N", ""]  # noqa: E501
         if ell_status not in allowed_values:
-            raise ValueError(
-                "Invalid value for `ell_status` ({0}), must be one of {1}"  # noqa: E501
-                .format(ell_status, allowed_values)
-            )
+            warnings.warn(f"Invalid value for ell_status: '{ell_status}'. Must be one of {allowed_values}. Defaulting to None.")
+            ell_status = None
 
         self._ell_status = ell_status
 


### PR DESCRIPTION
Asana: https://app.asana.com/1/1148144676484017/project/1205583592700124/task/1210080990260426?focus=true

This pull request introduces changes to the `clever/models/student.py` file to improve code maintainability and modify the behavior of the `ell_status` method. The most notable changes include replacing a `ValueError` with a warning in the `ell_status` method and updating imports.

### Behavior modification:
* [`clever/models/student.py`](diffhunk://#diff-c73e2c45a4c2040f30460aee09ec403ca3508e120066ba65552053a59261846aL220-R221): In the `ell_status` method, replaced the `ValueError` exception with a `warnings.warn` call to log invalid values for `ell_status` instead of raising an error. 

### Code maintainability:
* [`clever/models/student.py`](diffhunk://#diff-c73e2c45a4c2040f30460aee09ec403ca3508e120066ba65552053a59261846aL14-R15): Removed the `# noqa: F401` comment for the `re` import and added a new `warnings` import with the `# noqa: F401` comment to suppress unused import warnings.